### PR TITLE
ZO-5573: prometheus metric name and unit conversion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ dynamic = ["version", "readme"]
 dependencies = [
     "opentelemetry-sdk",
     "requests",
+    "opentelemetry-exporter-prometheus",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- common unit abbreviations are converted to Prometheus conventions (s -> seconds), following the collector's implementation
- unit annotations (enclosed in curly braces like {requests}) are stripped away
- units with slash are converted e.g. m/s -> meters_per_second.

- [Spezifikation](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.33.0/specification/compatibility/prometheus_and_openmetrics.md#otlp-metric-points-to-prometheus)
- siehe https://github.com/open-telemetry/opentelemetry-python/issues/2938